### PR TITLE
Add fastlane parameter

### DIFF
--- a/lib/phoenix/pubsub.rb
+++ b/lib/phoenix/pubsub.rb
@@ -52,15 +52,19 @@ module Phoenix
       private
 
       def serialize_message topic, event, payload
-        term = Erlang::Tuple[
-          # {@redis_msg_vsn, node_ref, pool_size, from_pid, topic, msg}
-          1, '', 1, :none, topic, {
-            :__struct__ => :"Elixir.Phoenix.Socket.Broadcast",
-            :event => event,
-            :payload => payload,
-            :topic => topic
-          }
-        ]
+        vsn = 1
+        node_ref = ''
+        fastlane = :nil
+        pool_size = 1
+        from_pid = :none
+        msg = {
+          :__struct__ => :"Elixir.Phoenix.Socket.Broadcast",
+          :event => event,
+          :payload => payload,
+          :topic => topic
+        }
+
+        term = Erlang::Tuple[vsn, node_ref, fastlane, pool_size, from_pid, topic, msg]
         Erlang.term_to_binary term
       end
     end

--- a/lib/phoenix/pubsub/version.rb
+++ b/lib/phoenix/pubsub/version.rb
@@ -1,5 +1,5 @@
 module Phoenix
   module Pubsub
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Add `fastlane` parameter to keep up with the redis adapter: https://github.com/phoenixframework/phoenix_pubsub_redis/commit/a4f5609a9861aadf846b3e0aff37ddf78435c726

Also bumped the version to 0.2.0 since it's kind of a breaking change.